### PR TITLE
fix: use valid regex pattern in virus-scan workflow

### DIFF
--- a/.github/workflows/virus-scan.yaml
+++ b/.github/workflows/virus-scan.yaml
@@ -6,8 +6,12 @@ on:
 
 jobs:
   virustotal:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'ptarmiganlabs'
+    if: |
+      github.event_name != 'pull_request' &&
+      github.repository_owner == 'ptarmiganlabs'
 
     steps:
       - name: VirusTotal Scan
@@ -17,4 +21,4 @@ jobs:
           request_rate: 4
           update_release_body: true
           files: |
-            *.zip
+            .zip$


### PR DESCRIPTION
## Problem

The `virus-scan.yaml` workflow fails with:

```
Invalid regular expression: /*.zip/: Nothing to repeat
```

The `files` parameter in `crazy-max/ghaction-virustotal` expects a **regex pattern**, not a glob. `*.zip` is invalid regex because `*` (zero or more of the preceding element) has nothing preceding it.

## Fix

- Changed `*.zip` to `.zip$` (valid regex matching filenames ending in `.zip`)
- Added `permissions: contents: write` (needed for `update_release_body: true`)
- Improved `if` condition to also exclude pull request events

These changes align with the working virus-scan workflows in the other repos (`butler-sos`, `qs-help-button`).